### PR TITLE
feat(links): 增加友链隐藏功能

### DIFF
--- a/annotation-setting.yaml
+++ b/annotation-setting.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1alpha1
+kind: AnnotationSetting
+metadata:
+  generateName: annotation-setting-
+spec:
+  targetRef:
+    group: core.halo.run
+    kind: LinkGroup
+  formSchema:
+    - $formkit: "select"
+      name: "hide"
+      label: "是否隐藏"
+      value: "false"
+      options:
+        - value: "true"
+          label: 是
+        - value: "false"
+          label: 否
+
+---
+apiVersion: v1alpha1
+kind: AnnotationSetting
+metadata:
+  generateName: annotation-setting-
+spec:
+  targetRef:
+    group: core.halo.run
+    kind: Link
+  formSchema:
+    - $formkit: "select"
+      name: "hide"
+      label: "是否隐藏"
+      value: "false"
+      options:
+        - value: "true"
+          label: 是
+        - value: "false"
+          label: 否

--- a/templates/links.html
+++ b/templates/links.html
@@ -1,4 +1,33 @@
-<!DOCTYPE html><html xmlns:th="https://www.thymeleaf.org"th:replace="~{modules/layout :: html(title = '友链 - ' + ${site.title}, hero = null, content = ~{::content}, head = null, footer = null,)}"><th:block th:fragment="content"><div class="post-content uk-animation-fade" itemprop="articleBody"><article><th:block th:each="group : ${groups}">  
-<h2>友情链接</h2>
-<div class="links"><div th:each="link : ${group.links}" :key="i" class="link-box"><div class="link-img-box"><img class="link-img"th:src="${link.spec.logo}" th:alt="${link.spec.displayName}" /></div><a class="link-img-a" th:href="${link.spec.url}" target="_blank"><p th:text="${link.spec.displayName}"></p><p th:text="${link.spec.description}"></p></a></div></div></th:block>
-</article><th:block th:replace="~{modules/comment :: comment(name=${pluginName},kind='Plugin',group='plugin.halo.run')}"></th:block></div></th:block></html>
+<!DOCTYPE html>
+<html th:replace="~{modules/layout :: html(title = '友链 - ' + ${site.title}, hero = null, content = ~{::content}, head = null, footer = null,)}"
+      xmlns:th="https://www.thymeleaf.org">
+<th:block th:fragment="content">
+    <div class="post-content uk-animation-fade" itemprop="articleBody">
+        <article>
+            <th:block th:each="group : ${groups}"
+                      th:if="${#annotations.getOrDefault(group, 'hide','false') == 'false'}">
+                <h2>[[${group.spec.displayName}]]</h2>
+                <div class="links">
+                    <div :key="i"
+                         class="link-box"
+                         th:each="link : ${group.links}"
+                         th:if="${#annotations.getOrDefault(link, 'hide','false') == 'false'}">
+                        <div class="link-img-box">
+                            <img class="link-img"
+                                 th:alt="${link.spec.displayName}"
+                                 th:src="${link.spec.logo}"/>
+                        </div>
+                        <a class="link-img-a"
+                           target="_blank"
+                           th:href="${link.spec.url}">
+                            <p th:text="${link.spec.displayName}"></p>
+                            <p th:text="${link.spec.description}"></p>
+                        </a>
+                    </div>
+                </div>
+            </th:block>
+        </article>
+        <th:block th:replace="~{modules/comment :: comment(name=${pluginName},kind='Plugin',group='plugin.halo.run')}"></th:block>
+    </div>
+</th:block>
+</html>


### PR DESCRIPTION
- 新增 AnnotationSetting 文件，为 LinkGroup 和 Link 添加隐藏选项
- 修改模板文件，根据注解判断是否显示友链和友链分组
- h2标签显示链接分组名称

分组隐藏

9分组隐藏5

![image](https://github.com/user-attachments/assets/db4cc5e0-c422-4c9d-b0a2-65f4c7408c90)
----
![image](https://github.com/user-attachments/assets/17bf6c09-e632-4ae2-a552-cd2e2fce9d10)


单链接隐藏

![image](https://github.com/user-attachments/assets/cbcb9391-668c-4135-a412-b90fc464d548)

![image](https://github.com/user-attachments/assets/f3cd86df-de39-42f8-b6ee-89652c2c6bda)


