### PR TITLE
Add cd workflow for theme releasing

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,18 @@
+name: CD
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  cd:
+    uses: halo-sigs/reusable-workflows/.github/workflows/theme-cd.yaml@v3
+    secrets:
+      halo-pat: ${{ secrets.HALO_PAT }}
+    permissions:
+      contents: write
+    with:
+      app-id: app-PNjRd
+      pnpm-version: 10
+      node-version: 20

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.DS_Store
+.vscode

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "build": "npx @halo-dev/theme-package-cli"
+  },
+  "packageManager": "pnpm@10.6.5+sha512.cdf928fca20832cd59ec53826492b7dc25dc524d4370b6b4adbf65803d32efaa6c1c88147c0ae4e8d579a6c9eec715757b50d4fa35eea179d868eada4ed043af"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}


### PR DESCRIPTION
添加 cd.yaml，用于在创建 Release 之后同步在 Halo 应用市场发布版本。

合并此 PR 之后需要在 https://github.com/MagicBreeze/halo-theme-Ying/settings/secrets/actions 创建一个名为 `HALO_PAT` 的 Secret，PAT 需要去 https://www.halo.run/uc/profile?tab=pat 创建，勾选 `应用市场开发者 -> 版本管理` 的权限。

需要注意的是，虽然这个流程会自动打包并发布到应用市场，但在发布版本之前仍然需要手动修改 theme.yaml 的版本号。

详情可见：https://github.com/halo-sigs/reusable-workflows